### PR TITLE
docs: add brutils-python to python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,11 @@ Alan de Freitas](https://github.com/alandefreitas)
 
 ### Python
 
+- **[brutils-python](https://github.com/brazilian-utils/brutils-python)** by [brazilian-utils](https://github.com/brazilian-utils)  
+  Utils library for validating and generating Brazilian documents like CPF, CNPJ, CEP and more  
+  ![Stars](https://img.shields.io/github/stars/brazilian-utils/brutils-python?style=flat-square)
+ [![license](https://img.shields.io/github/license/brazilian-utils/brutils-python.svg)](/LICENSE)
+
 - **[Calculadora do Cidadão](https://github.com/cuducos/calculadora-do-cidadao)** by [cuducos](https://github.com/cuducos)  
   Tool for Brazilian Reais monetary adjustment/correction  
   ![Stars](https://img.shields.io/github/stars/cuducos/calculadora-do-cidadao?style=flat-square)


### PR DESCRIPTION
Adding brutils-python, a utils library for Brazilian documents validation (CPF, CNPJ, CEP). It has 400+ stars and is maintained by the brazilian-utils community.

## Contributing

(the same measurement rule as [awesome-made-by-russians ](https://github.com/gaearon/awesome-made-by-russians))

It's hard to calculate project popularity so we use stars to measure it. It's not quite fair, but it is what we have here on Github.

If you want to add a project to this list, please make sure that:

- [x] The project was created by the developers born in Brazil
- [x] The project can't be just a personal, experimental or sample project
- [x] The project has more than **100 stars** on Github
- [x] Place them in alphabetical order
- [x] One repository per PR/contribution - _avoid conflicts and simplify review_
- [x] Check if your suggestion follows our pattern (title, description, badge), you need to add double blank space after ending line of each line

If they meet the requirements above, feel free to create a PR! 😁