### PR TITLE
Add Crime Brasil (Apps, Softwares & Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@
   Job aggregator for developers  
   ![Stars](https://img.shields.io/github/stars/LarissaAbreu/contrata-se-dev.svg?style=flat-square)
  [![license](https://img.shields.io/github/license/LarissaAbreu/contrata-se-dev.svg)](/LICENSE)
+- **[Crime Brasil](https://crimebrasil.com.br)** by [valdovaldo1500-cell](https://github.com/valdovaldo1500-cell)  
+  Open-data platform for Brazilian crime statistics. Neighborhood-level coverage in Rio Grande do Sul (2.99M incidents, 99.99% geocoded), municipality-level for MG and RJ, plus national PRF and DATASUS data. Free REST API, CSV exports, CC BY 4.0.
+
 
 - **[DevHub](https://github.com/devhubapp/devhub)** by [brunolemos](https://github.com/brunolemos)  
   GitHub Notifications manager for Desktop and Mobile (99% code sharing using react-native-web)  


### PR DESCRIPTION
## Adds: [Crime Brasil](https://crimebrasil.com.br)

Inserted alphabetically in **Apps, Softwares & Tools** between "contrata-se-dev" and "DevHub".

## What it is

Crime Brasil is an open-data platform for Brazilian crime statistics — solo BR project, bootstrapped, operating since 2025. Key numbers:

- Rio Grande do Sul: 2.99M incidents 2022–2025, 497 municipalities, 79,024 neighborhoods, 99.99% geocoded
- Minas Gerais: ~965K violent crimes (municipality-level)
- Rio de Janeiro: ~37K ISP/CISP records (municipality-level)
- National: PRF DATATRAN + DATASUS SINAN
- Free REST API + CSV/Parquet exports
- License: CC BY 4.0

## Disclosure

I'm the maintainer. The core code is currently private but the data, API, and map are fully public. Happy to adjust the entry format (e.g., remove GitHub author attribution, or move to a different section) if you prefer.